### PR TITLE
fix block debug/verify format-truncation sizes

### DIFF
--- a/block/blkdebug.c
+++ b/block/blkdebug.c
@@ -672,6 +672,7 @@ static void blkdebug_refresh_filename(BlockDriverState *bs, QDict *options)
     QDict *opts;
     const QDictEntry *e;
     bool force_json = false;
+    const char* debugFormatter = "blkdebug:%s:%s";
 
     for (e = qdict_first(options); e; e = qdict_next(options, e)) {
         if (strcmp(qdict_entry_key(e), "config") &&
@@ -689,8 +690,8 @@ static void blkdebug_refresh_filename(BlockDriverState *bs, QDict *options)
     }
 
     if (!force_json && bs->file->bs->exact_filename[0]) {
-        snprintf(bs->exact_filename, sizeof(bs->exact_filename),
-                 "blkdebug:%s:%s", s->config_file ?: "",
+        snprintf(bs->exact_filename, sizeof(bs->exact_filename) + sizeof(debugFormatter),
+                 debugFormatter, s->config_file ?: "",
                  bs->file->bs->exact_filename);
     }
 

--- a/block/blkverify.c
+++ b/block/blkverify.c
@@ -282,6 +282,7 @@ static bool blkverify_recurse_is_first_non_filter(BlockDriverState *bs,
 
 static void blkverify_refresh_filename(BlockDriverState *bs, QDict *options)
 {
+    const char* verifyFormatter = "blkverify:%s:%s";
     BDRVBlkverifyState *s = bs->opaque;
 
     /* bs->file->bs has already been refreshed */
@@ -305,8 +306,8 @@ static void blkverify_refresh_filename(BlockDriverState *bs, QDict *options)
     if (bs->file->bs->exact_filename[0]
         && s->test_file->bs->exact_filename[0])
     {
-        snprintf(bs->exact_filename, sizeof(bs->exact_filename),
-                 "blkverify:%s:%s",
+        snprintf(bs->exact_filename, sizeof(bs->exact_filename) + sizeof(verifyFormatter),
+                 verifyFormatter,
                  bs->file->bs->exact_filename,
                  s->test_file->bs->exact_filename);
     }


### PR DESCRIPTION
Build fails with GCC 7.1.1 
```
block/blkdebug.c: In function ‘blkdebug_refresh_filename’:                                                                                                                                     
block/blkdebug.c:693:31: error: ‘%s’ directive output may be truncated writing up to 4095 bytes into a region of size 4086 [-Werror=format-truncation=]                                        
                  "blkdebug:%s:%s", s->config_file ?: "",                                                                                                                                      
                               ^~                                                                                                                                                              
block/blkdebug.c:692:9: note: ‘snprintf’ output 11 or more bytes (assuming 4106) into a destination of size 4096                                                                               
         snprintf(bs->exact_filename, sizeof(bs->exact_filename),                                                                                                                              
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                                                                                                                              
                  "blkdebug:%s:%s", s->config_file ?: "",                                                                                                                                      
                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                                                                                                                                      
                  bs->file->bs->exact_filename);                                                                                                                                               
                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                                                                                                                                                
block/blkverify.c: In function ‘blkverify_refresh_filename’:                                                                                                                                   
block/blkverify.c:309:29: error: ‘%s’ directive output may be truncated writing up to 4095 bytes into a region of size 4086 [-Werror=format-truncation=]                                       
                  "blkverify:%s:%s",                                                                                                                                                           
                             ^~                                                                                                                                                               
block/blkverify.c:308:9: note: ‘snprintf’ output between 12 and 8202 bytes into a destination of size 4096                                                                                     
         snprintf(bs->exact_filename, sizeof(bs->exact_filename),                                                                                                                              
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                                                                                                                              
                  "blkverify:%s:%s",                                                                                                                                                           
                  ~~~~~~~~~~~~~~~~~~                                                                                                                                                           
                  bs->file->bs->exact_filename,                                                                                                                                                
                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                                                                                                                                                
                  s->test_file->bs->exact_filename);                                                                                                                                           
                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~    
```
